### PR TITLE
fix: 修复在实际配方速度低于5tick的情况下，单方块采矿机管道不能回收的bug

### DIFF
--- a/src/main/java/cn/elytra/gtnh/cutcorners/mixinloader/CCMixinLoader.java
+++ b/src/main/java/cn/elytra/gtnh/cutcorners/mixinloader/CCMixinLoader.java
@@ -28,6 +28,7 @@ public class CCMixinLoader implements ILateMixinLoader {
             mixins.add("gregtech.GT_MetaTileEntity_MinerMixin");
             mixins.add("gregtech.GT_MetaTileEntity_MultiFurnaceMixin");
             mixins.add("gregtech.GT_MetaTileEntity_DrillerBaseMixin");
+            mixins.add("gregtech.GT_DrillingLogicDelegateMixin");
             mixins.add("gregtech.EyeOfHarmonyRecipeAccessor");
             mixins.add("gregtech.EyeOfHarmonyFrontendFixMixin");
 

--- a/src/main/java/cn/elytra/gtnh/cutcorners/mixins/late/gregtech/GT_DrillingLogicDelegateMixin.java
+++ b/src/main/java/cn/elytra/gtnh/cutcorners/mixins/late/gregtech/GT_DrillingLogicDelegateMixin.java
@@ -1,0 +1,17 @@
+package cn.elytra.gtnh.cutcorners.mixins.late.gregtech;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import gregtech.common.misc.DrillingLogicDelegate;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = DrillingLogicDelegate.class, remap = false)
+public class GT_DrillingLogicDelegateMixin {
+
+    @ModifyExpressionValue(
+        method = "onPostTickRetract",
+        at = @At(value = "INVOKE", target = "Lgregtech/common/misc/IDrillingLogicDelegateOwner;getMachineSpeed()I"))
+    private int gtnhcc$ensureMinRetractSpeed(int original) {
+        return Math.max(original, 5);
+    }
+}


### PR DESCRIPTION
# 原因
在管道回收的时候会根据机器速度做取模计算，当实际的`getMachineSpeed`即采矿机的`mspeed`低于5，取模值就变成了0，从而抛出计算异常导致回收管道逻辑中止
<img width="771" height="347" alt="Image" src="https://github.com/user-attachments/assets/d9ac1a80-00f7-4cc0-9c0f-35526ddaf2dd" />
# 表现
<img width="1306" height="617" alt="image" src="https://github.com/user-attachments/assets/471d9060-9675-4e81-af57-862404d8270b" />
# 解决手段
增加mixin，当mspeed低于5tick时设置为5tick

closed #12, #14