### PR TITLE
fix: runMachineApplied 空指针异常

### DIFF
--- a/src/main/java/cn/elytra/gtnh/cutcorners/mixins/late/gregtech/MTEMultiBlockBaseMixin.java
+++ b/src/main/java/cn/elytra/gtnh/cutcorners/mixins/late/gregtech/MTEMultiBlockBaseMixin.java
@@ -1,5 +1,6 @@
 package cn.elytra.gtnh.cutcorners.mixins.late.gregtech;
 
+import cn.elytra.gtnh.cutcorners.CutCorners;
 import cn.elytra.gtnh.cutcorners.config.CutCornersConfig;
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.MTEMultiBlockBase;
@@ -10,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.Collections;
 import java.util.List;
 
 @Mixin(value = MTEMultiBlockBase.class, remap = false)
@@ -17,18 +19,44 @@ public class MTEMultiBlockBaseMixin {
 
     @Shadow
     public int mMaxProgresstime;
+
     @Unique
     private static List<Class<?>> gtnhcc$runMachineApplied;
 
-    @Inject(method = "<clinit>", at = @At("TAIL"))
-    private static void gtnhcc$initClassList(CallbackInfo ci) {
-        CutCornersConfig.onUpdateAndNow(() -> gtnhcc$runMachineApplied = CutCornersConfig.instance.getMaxProgressTimeRunMachineClasses());
+    @Unique
+    private static boolean gtnhcc$runMachineAppliedInitialized = false;
+
+    @Unique
+    private static void gtnhcc$ensureRunMachineAppliedInitialized() {
+        if (gtnhcc$runMachineAppliedInitialized) return;
+        gtnhcc$runMachineAppliedInitialized = true;
+
+        // Lazy init: runs the first time any MTEMultiBlockBase calls runMachine.
+        // This works around late mixin <clinit> not executing on already-loaded classes.
+        try {
+            gtnhcc$runMachineApplied = CutCornersConfig.instance.getMaxProgressTimeRunMachineClasses();
+        } catch (Exception e) {
+            CutCorners.LOG.error("Failed to initialize runMachine acceleration list", e);
+            gtnhcc$runMachineApplied = Collections.emptyList();
+        }
+
+        // Also register for config updates so changes take effect without restart
+        CutCornersConfig.onUpdate(() -> {
+            try {
+                gtnhcc$runMachineApplied = CutCornersConfig.instance.getMaxProgressTimeRunMachineClasses();
+            } catch (Exception e) {
+                CutCorners.LOG.error("Failed to update runMachine acceleration list", e);
+                gtnhcc$runMachineApplied = Collections.emptyList();
+            }
+        });
     }
 
     @Inject(method = "runMachine", at = @At("HEAD"))
     private void gtnhcc$hookRunMachine(IGregTechTileEntity aBaseMetaTileEntity, long aTick, CallbackInfo ci) {
         if (mMaxProgresstime > 0) {
-            if (gtnhcc$runMachineApplied.contains(getClass())) {
+            gtnhcc$ensureRunMachineAppliedInitialized();
+            // Defensive null check in case initialization failed silently
+            if (gtnhcc$runMachineApplied != null && gtnhcc$runMachineApplied.contains(getClass())) {
                 mMaxProgresstime = 1;
             }
         }


### PR DESCRIPTION
## commit内容:

- 采用懒加载策略,将注入延后到机器调用
- 调用前增加空值检查,用异常处理防止机器崩溃

## 方案如下:
- 删除静态初始化,将初始化延后至第一个机器的调用,避免因为GT的类早于本mod加载而导致list为空触发NPE
- 增加空值检查,出现异常后,降级至机器原配置(也就是mod不生效但是机器依旧可以运行)

## 验证结果:

-大型蒸汽锻造锤可以正常使用并以1tick速度运行