### PR TITLE
倍率过高情况下单方块矿机报“除零”错误，尝试修复

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
-networkTimeout=30000
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -70,11 +70,10 @@ goto fail
 :execute
 @rem Setup the command line
 
-set CLASSPATH=
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,5 +24,5 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '2.0.7'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '2.0.24'
 }

--- a/src/main/java/cn/elytra/gtnh/cutcorners/mixins/late/gregtech/GT_DrillingLogicDelegateMixin.java
+++ b/src/main/java/cn/elytra/gtnh/cutcorners/mixins/late/gregtech/GT_DrillingLogicDelegateMixin.java
@@ -13,9 +13,6 @@ public class GT_DrillingLogicDelegateMixin {
         method = "onPostTickRetract",
         at = @At(value = "INVOKE", target = "Lgregtech/common/misc/IDrillingLogicDelegateOwner;getMachineSpeed()I"))
     private int gtnhcc$ensureMinRetractSpeed(int original) {
-        if (CutCorners.getStrategy().isImmediateMode()) {
-            return 5;
-        }
-        return original;
+        return 5;
     }
 }

--- a/src/main/java/cn/elytra/gtnh/cutcorners/mixins/late/gregtech/MTEMultiBlockBaseMixin.java
+++ b/src/main/java/cn/elytra/gtnh/cutcorners/mixins/late/gregtech/MTEMultiBlockBaseMixin.java
@@ -28,10 +28,10 @@ public class MTEMultiBlockBaseMixin {
     @Inject(method = "runMachine", at = @At("HEAD"))
     private void gtnhcc$hookRunMachine(IGregTechTileEntity aBaseMetaTileEntity, long aTick, CallbackInfo ci) {
         if (mMaxProgresstime > 0) {
-            if (gtnhcc$runMachineApplied.contains(getClass())) {
+            if (gtnhcc$runMachineApplied != null && gtnhcc$runMachineApplied.contains(getClass())) {
                 mMaxProgresstime = 1;
             }
         }
     }
-
 }
+


### PR DESCRIPTION
```
[01:33:37] [Server thread/ERROR] [GregTech GTNH]: Error ticking meta tile entity 681 at (-216, 69, 168) in world 0
java.lang.ArithmeticException: / by zero
	at Launch//gregtech.common.misc.DrillingLogicDelegate.onPostTickRetract(DrillingLogicDelegate.java:126) ~[DrillingLogicDelegate.class:?]
	at Launch//gregtech.common.misc.DrillingLogicDelegate.onOwnerPostTick(DrillingLogicDelegate.java:108) ~[DrillingLogicDelegate.class:?]
	at Launch//gregtech.common.tileentities.machines.basic.MTEMiner.onPostTick(MTEMiner.java:201) ~[MTEMiner.class:?]
	at Launch//gregtech.api.metatileentity.BaseMetaTileEntity.doPostTick(BaseMetaTileEntity.java:371) ~[BaseMetaTileEntity.class:?]
	at Launch//gregtech.api.metatileentity.BaseMetaTileEntity.updateEntityProfiled(BaseMetaTileEntity.java:337) ~[BaseMetaTileEntity.class:?]
	at Launch//gregtech.api.metatileentity.CommonBaseMetaTileEntity.func_145845_h(CommonBaseMetaTileEntity.java:146) [CommonBaseMetaTileEntity.class:?]
	at Launch//net.minecraft.world.World.func_72939_s(World.java:1939) [ahb.class:?]
	at Launch//net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489) [mt.class:?]
	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:111) [bsx.class:?]
	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427) [MinecraftServer.class:?]
	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685) [?:?]
```